### PR TITLE
Make connected-wires with pulled-up pins

### DIFF
--- a/connected-wires.py
+++ b/connected-wires.py
@@ -42,19 +42,27 @@ def read_pins(pins):
     conns = {}
     for i in range(0, len(pins)):
         ipin = pins[i]
-        pi.set_mode(ipin, pigpio.OUTPUT)
-        pi.write(ipin, 1)
-        vals = pi.read_bank_1()
-        pi.set_mode(ipin, pigpio.INPUT)
-        pi.set_pull_up_down(ipin, pigpio.PUD_DOWN)
-        # print("i=" + str(i) + " vals=" + '{:032b}'.format(vals))
-        conns[str(i)] = []
-        for j in range(0, len(pins)):
-            jpin = pins[j]
-            if i == j:
-                continue
-            if (1 << jpin) & vals:
-                conns[str(i)].append(j)
+
+        state = pi.read(ipin)
+        if state:
+            # Pin is externally pulled up. Every other pin will report this pin to be connected due
+            # to the pull-up, thus emulate this by reporting every pin to be connected to this one.
+            conns[str(i)] = list(range(0, len(pins)))
+        else:
+            # Regular logic. Set pin to output / high and see which pins are afterwards HIGH.
+            pi.set_mode(ipin, pigpio.OUTPUT)
+            pi.write(ipin, 1)
+            vals = pi.read_bank_1()
+            pi.set_mode(ipin, pigpio.INPUT)
+            pi.set_pull_up_down(ipin, pigpio.PUD_DOWN)
+            # print("i=" + str(i) + " vals=" + '{:032b}'.format(vals))
+            conns[str(i)] = []
+            for j in range(0, len(pins)):
+                jpin = pins[j]
+                if i == j:
+                    continue
+                if (1 << jpin) & vals:
+                    conns[str(i)].append(j)
     return conns
 
 


### PR DESCRIPTION
Button board uses the connected-wires task box, but many buttons instead of connecting wires pulls the pin up.  According to current logic, pulling a pin up looks like all other pins are connected to this pin, but this pin is not connected to any others.  

This PR adds logic so it seems that a pulled-up pin is connected to all other pins and vice versa.  It also avoids a short circuit when trying to output 0 to a pulled-up pin.  ⚡ 